### PR TITLE
Fix module script mime type error

### DIFF
--- a/.github/workflows/azure-staticwebapp.yml
+++ b/.github/workflows/azure-staticwebapp.yml
@@ -21,7 +21,7 @@ on:
 
 # Environment variables available to all jobs and steps in this workflow
 env:
-  APP_LOCATION: "/" # location of your client code
+  APP_LOCATION: "dist" # location of built client code to deploy
   API_LOCATION: "" # location of your api source code - optional
   APP_ARTIFACT_LOCATION: "dist" # location of client code build output
   AZURE_STATIC_WEB_APPS_API_TOKEN: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN }} # secret containing deployment token for your static web app


### PR DESCRIPTION
Update Azure Static Web Apps `APP_LOCATION` to `dist` to resolve module script MIME-type errors.

The previous configuration deployed the project root, causing the Azure Static Web App to serve pre-built JavaScript modules with an incorrect `application/octet-stream` MIME type. This change ensures the workflow correctly points to Vite's build output, allowing modules to be served with the proper `application/javascript` MIME type.

---
Linear Issue: [JAK-36](https://linear.app/jakubsvobodacz/issue/JAK-36/adjust-the-hero-section-text)

<a href="https://cursor.com/background-agent?bcId=bc-5a54a52c-1974-45c8-8717-b51c2b07014f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5a54a52c-1974-45c8-8717-b51c2b07014f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

